### PR TITLE
#35198: Log metrics for apps launched outside of registered command framework

### DIFF
--- a/app.py
+++ b/app.py
@@ -226,7 +226,7 @@ class FlameReview(Application):
 
         # Log usage metrics
         try:
-            self.log_metric("Export")
+            self.log_metric("Version Create")
             self.engine.log_user_attribute_metric(
                 "%s version" % (self.name,),
                 self.version,

--- a/app.py
+++ b/app.py
@@ -99,7 +99,14 @@ class FlameReview(Application):
             info["presetPath"] = self.execute_hook_method("settings_hook", "get_export_preset")
     
             self.log_debug("%s: Starting custom export session with preset '%s'" % (self, info["presetPath"]))
-                
+
+        # Log usage metrics
+        try:
+            self.log_metric("Sequence Export", log_version=True)
+        except:
+            # ingore any errors. ex: metrics logging not supported
+            pass
+
     def adjust_path(self, session_id, info):
         """
         Flame hook called when an item is about to be exported and a path needs to be computed.
@@ -224,17 +231,6 @@ class FlameReview(Application):
         # done!
         self._submission_done = True
 
-        # Log usage metrics
-        try:
-            self.log_metric("Version Create")
-            self.engine.log_user_attribute_metric(
-                "%s version" % (self.name,),
-                self.version,
-            )
-        except:
-            # ingore any errors. ex: metrics logging not supported
-            pass
-        
     def backburner_populate_shotgun(self, info, comments):
         """
         This method is called via backburner and therefore runs in the background.

--- a/app.py
+++ b/app.py
@@ -223,6 +223,17 @@ class FlameReview(Application):
         
         # done!
         self._submission_done = True
+
+        # Log usage metrics
+        try:
+            self.log_metric("Export")
+            self.engine.log_user_attribute_metric(
+                "%s version" % (self.name,),
+                self.version,
+            )
+        except:
+            # ingore any errors. ex: metrics logging not supported
+            pass
         
     def backburner_populate_shotgun(self, info, comments):
         """


### PR DESCRIPTION
This change logs the app version and one action metric for "export".