### PR TITLE
#36094 Upgraded to use built-in presets

### DIFF
--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -9,9 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sgtk
-from sgtk import TankError
 import os
-import re
+
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -29,169 +28,11 @@ class ExportSettings(HookBaseClass):
         
         :returns: Path on disk to Flame export preset 
         """
-        return self._generate_profile_xml()
+        # base it on one of the default presets that ship with Flame.
+        return os.path.join(
+            self.parent.engine.install_root,
+            "presets",
+            self.parent.engine.flame_version,
+            "export/presets/flame/movie_file/QuickTime (H.264 720p 8Mbits).xml"
+        )
 
-    ###############################################################################################
-    # helper methods and internals
-    
-    def _write_content_to_file(self, content, file_name):
-        """
-        Helper method. Writes content to file and returns the path.
-        The content will be written to the app specific cache location 
-        on disk, organized by app instance name. The rationale is that 
-        each app instance holds its own configuration, and the configuration
-        generates one set of unique xml files.
-        
-        :param content: Data to write to the file
-        :param file_name: The name of the file to create
-        :returns: path to the created file
-        """
-        # determine location
-        folder = os.path.join(self.parent.cache_location, self.parent.instance_name)
-        file_path = os.path.join(folder, file_name)
-
-        # create folders
-        if not os.path.exists(folder):
-            old_umask = os.umask(0)
-            os.makedirs(folder, 0777)
-            os.umask(old_umask)
-        
-        # write data
-        fh = open(file_path, "wt")
-        fh.write(content)
-        fh.close()
-        
-        self.parent.log_debug("Wrote temporary file '%s'" % file_path)
-        return file_path
-        
-    def _generate_quicktime_settings(self):
-        """
-        Generate quicktime codec presets and return the path to 
-        the generated file.
-        
-        :returns: path to quicktime codec presets (.cdxprof) xml file
-        """ 
-
-        xml = """<?xml version="1.0" encoding="UTF-8"?>
-<codecprofile version="1.0">
-   <format name="QuickTime">
-      <essence name="video">
-         <provider name="libquicktime">
-            <codec name="H264E" longname="H264" type="video" description="Main Concept H264 Codec">
-               <params presetName="High_Blu_Ray_8Mbits">
-                  <param name="Target preset" internalname="target_preset" description="" type="enum" value="H264_BD" />
-                  <param name="Frame-type options" internalname="frame_type" description="" type="section" />
-                  <param name="GOP size" internalname="idr_interval" description="" type="int" min="1" max="300" value="30" />
-                  <param name="B-Frames" internalname="numBframes" description="Number of B-frames between I and P" type="int" min="0" max="3" value="2" />
-                  <param name="Adaptive B-frame decision" internalname="adaptive_b_frames" description="" type="bool" value="1" />
-                  <param name="Automatic scene detection" internalname="vcsd_mode" description="" type="bool" value="1" />
-                  <param name="Rate control" internalname="ratecontrol" description="" type="section" />
-                  <param name="Rate control method" internalname="bit_rate_mode" description="" type="enum" value="Average bitrate" />
-                  <param name="Bitrate" internalname="bit_rate" description="Bitrate in kbit/s. (Used in bitrate mode.)" type="int" min="1" max="1000000" value="8000" />
-                  <param name="Max bitrate" internalname="max_bit_rate" description="Max bitrate in kbit/s. Must be greater than the bitrate. (Used in bitrate mode.)" type="int" min="1" max="1000000" value="9999" />
-                  <param name="I-frame quantizer" internalname="quant_pI" description="Quantization value for I-frames. (Used in quantizer mode.)" type="int" min="1" max="51" value="24" />
-                  <param name="P-frame quantizer" internalname="quant_pP" description="Quantization value for P-frames. (Used in quantizer mode.)" type="int" min="1" max="51" value="25" />
-                  <param name="B-frame quantizer" internalname="quant_pB" description="Quantization value for B-frames. (Used in quantizer mode.)" type="int" min="1" max="51" value="27" />
-                  <param name="Minimum quantizer" internalname="min_quant" description="Minimum quantization value. (Used in both mode.)" type="int" min="1" max="51" value="0" />
-                  <param name="Maximum quantizer" internalname="max_quant" description="Maximum quantization value. (Used in both mode.)" type="int" min="1" max="51" value="51" />
-                  <param name="Advanced" internalname="advanced" description="" type="section" />
-                  <param name="Optimize rate-distortion cost" internalname="rd_optimization" description="" type="bool" value="1" />
-               </params>
-            </codec>
-         </provider>
-      </essence>
-   </format>
-</codecprofile>
-        """
-        
-        path = self._write_content_to_file(xml, "quicktime_settings.cdxprof")
-        return path
-    
-    def _generate_profile_xml(self):
-        """
-        Generate Flame export profile settings suitable for generating a single quicktime 
-        file to represent an entire sequence.
-        
-        :returns: path to export preset xml file
-        """
-        
-        # this profile is a 8-bit QuickTime file (H.264 1280x720 8Mbits) with 
-        # preset High_Blu_Ray_8Mbits, suitable for upload to Shotgun Review.
-        #
-        # for more details around quicktime settings and shotgun, see
-        # https://support.shotgunsoftware.com/entries/26303513-Transcoding
-        
-        # a note on xml file formats: 
-        # Each major version of Flame typically implements a particular 
-        # version of the preset xml protocol. This is denoted by a preset version
-        # number in the xml file. In order for the integration to run smoothly across
-        # multiple versions of Flame, Flame ideally needs to be presented with a preset
-        # which matches the current preset version. If you present an older version, a
-        # warning dialog may pop up which is confusing to users. Therefore, make sure that
-        # we always generate xmls with a matching preset version.   
-        preset_version = self.parent.engine.preset_version
-        
-        xml = """<?xml version="1.0" encoding="UTF-8"?>
-<preset version="%s">
-   <type>movie</type>
-   <comment>Creates an 8-bit QuickTime file (H.264 1280x720 8Mbits).</comment>
-   <movie>
-      <fileType>QuickTime</fileType>
-      <namePattern></namePattern>
-      <yuvHeadroom>False</yuvHeadroom>
-      <yuvColourSpace>PCS_UNKNOWN</yuvColourSpace>
-      <operationalPattern>None</operationalPattern>
-      <companyName>Autodesk</companyName>
-      <productName />
-      <versionName />
-   </movie>
-   <video>
-      <fileType>QuickTime</fileType>
-      <codec>33622016</codec>
-      <codecProfile>{CODE_PROFILE_PATH}</codecProfile>
-      <namePattern></namePattern>
-      <compressionQuality>50</compressionQuality>
-      <transferCharacteristic>2</transferCharacteristic>
-      <colorimetricSpecification>4</colorimetricSpecification>
-      <publishLinked>False</publishLinked>
-      <foregroundPublish>False</foregroundPublish>
-      <overwriteWithVersions>False</overwriteWithVersions>
-      <resize>
-         <resizeType>fit</resizeType>
-         <resizeFilter>lanczos</resizeFilter>
-         <width>1280</width>
-         <height>720</height>
-         <bitsPerChannel>8</bitsPerChannel>
-         <numChannels>3</numChannels>
-         <floatingPoint>False</floatingPoint>
-         <bigEndian>True</bigEndian>
-         <pixelRatio>1</pixelRatio>
-         <scanFormat>P</scanFormat>
-      </resize>
-   </video>
-   <audio>
-      <fileType>QuickTime</fileType>
-      <codec>4026601474</codec>
-      <codecProfile />
-      <namePattern></namePattern>
-      <mixdown>AsIs</mixdown>
-      <sampleRate>48000</sampleRate>
-      <bitRate>128</bitRate>
-      <bitDepth>-1</bitDepth>
-   </audio>
-   <name>
-      <framePadding>8</framePadding>
-      <startFrame>0</startFrame>
-      <useTimecode>False</useTimecode>
-   </name>
-</preset>
-        """ % preset_version
-        # first generate the quicktime presets and bind this up to the content above
-        quicktime_settings_path = self._generate_quicktime_settings()
-        # plug in the path to the quicktime preset
-        resolved_xml = xml.replace("{CODE_PROFILE_PATH}", quicktime_settings_path)
-        # write it to disk
-        preset_path = self._write_content_to_file(resolved_xml, "export_preset.xml")
-        
-        return preset_path
-        

--- a/info.yml
+++ b/info.yml
@@ -50,7 +50,7 @@ description: "Sends sequences in Flame to Shotgun Review."
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.14.76"
-requires_engine_version: "v1.2.0"
+requires_engine_version: "v1.5.11"
 
 # the frameworks required to run this app
 frameworks:

--- a/info.yml
+++ b/info.yml
@@ -50,7 +50,7 @@ description: "Sends sequences in Flame to Shotgun Review."
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.14.76"
-requires_engine_version: "v1.5.11"
+requires_engine_version: "v1.6.0"
 
 # the frameworks required to run this app
 frameworks:


### PR DESCRIPTION
Changes the hook to use the export presets that are built into flame rather than
keeping a copy in the app. This better reflects best practices in Flame.