### PR TITLE
Fix Submit for Shotgun Review when overriding python hook path

### DIFF
--- a/app.py
+++ b/app.py
@@ -152,6 +152,8 @@ class FlameReview(Application):
         
         # ensure each quicktime gets a unique name
         info["resolvedPath"] = "shotgun_%s.mov" % uuid.uuid4().hex
+        # use Flame to run the post-export callbacks (not backburner)
+        info["useBackburner"] = False
          
         
     def populate_shotgun(self, session_id, info):

--- a/app.py
+++ b/app.py
@@ -152,6 +152,9 @@ class FlameReview(Application):
         
         # ensure each quicktime gets a unique name
         info["resolvedPath"] = "shotgun_%s.mov" % uuid.uuid4().hex
+        # If client override DL_PYTHON_HOOK_PATH env var, it changes the order python hook
+        # are triggered and can change the value of the global hook useBackburnerPostExportAsset.
+        # "useBackburner" bypass the global option and set the option for that specific export job.
         # use Flame to run the post-export callbacks (not backburner)
         info["useBackburner"] = False
          


### PR DESCRIPTION
The problem : 
When overriding the python hook path (DL_PYTHON_HOOK_PATH). You are changing the order in which python hook are initialized. This shouldn't be a problem except for one hook, useBackburnerPostExportAsset(). This is a global setting and will mess up "Submit for Shotgun Review" if it is set to True.

The solution : 
Use the dictionary option "useBackburner" that was added in 2018 to mitigate this problem. This options, which is applied by job, have precedence over the global option.