### PR TITLE
Fix missing codec when sending to review with Flame Trial

### DIFF
--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -28,10 +28,19 @@ class ExportSettings(HookBaseClass):
         
         :returns: Path on disk to Flame export preset 
         """
-        # base it on one of the default presets that ship with Flame.
-        return os.path.join(
-            self.parent.engine.export_presets_root,
-            "movie_file",
-            "QuickTime (H.264 720p 8Mbits).xml"
-        )
+        
+        if self.parent.engine.is_version_less_than("2018.1") :
+            # base it on one of the default presets that ship with Flame.
+            return os.path.join(
+                self.parent.engine.export_presets_root,
+                "movie_file",
+                "QuickTime (H.264 720p 8Mbits).xml"
+            )
+        else :
+            # base it on one of the default presets that ship with Flame.
+            return os.path.join(
+                self.parent.engine.export_presets_root,
+                "shotgun",
+                "Submit for review.xml"
+            )
 

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -40,7 +40,7 @@ class ExportSettings(HookBaseClass):
             # base it on one of the default presets that ship with Flame.
             return os.path.join(
                 self.parent.engine.export_presets_root,
-                "shotgun",
+                "movie_file",
                 "Submit for review.xml"
             )
 

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -28,19 +28,20 @@ class ExportSettings(HookBaseClass):
         
         :returns: Path on disk to Flame export preset 
         """
-        
-        if self.parent.engine.is_version_less_than("2018.1") :
-            # base it on one of the default presets that ship with Flame.
-            return os.path.join(
-                self.parent.engine.export_presets_root,
-                "movie_file",
-                "QuickTime (H.264 720p 8Mbits).xml"
-            )
-        else :
-            # base it on one of the default presets that ship with Flame.
-            return os.path.join(
-                self.parent.engine.export_presets_root,
-                "movie_file",
-                "Submit for review.xml"
-            )
-
+        # Use the "Submit for review" preset if it exist. This preset is packaged with flame 
+        # in new version and will point to an available codec depending on the flavour. This
+        # also give the opportunity to clients to override this preset if needs be.
+        preset_path = os.path.join(
+            self.parent.engine.export_presets_root,
+            "movie_file",
+            "Submit for review.xml"
+        )
+        if os.access(preset_path, os.R_OK) :
+            return preset_path
+ 
+        # fallback on one of the default presets that ship with Flame.
+        return os.path.join(
+            self.parent.engine.export_presets_root,
+            "movie_file",
+            "QuickTime (H.264 720p 8Mbits).xml"
+        )


### PR DESCRIPTION
Added a "Send for review" export preset that is packaged in flame.
This will allow flame to set the appropriate preset from the available codecs.
Flame Trial have access to less codecs then Flame.
