### PR TITLE
SG-43662 Set minimum Python version to 3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -38,6 +38,6 @@ repos:
     - id: check-yaml
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
     - id: black

--- a/app.py
+++ b/app.py
@@ -78,7 +78,7 @@ class FlameReview(Application):
 
         # pop up a UI asking the user for description
         tk_flame_review = self.import_module("tk_flame_review")
-        (return_code, widget) = self.engine.show_modal(
+        return_code, widget = self.engine.show_modal(
             "Submit for Review", self, tk_flame_review.SubmitDialog
         )
 

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -11,7 +11,6 @@
 import sgtk
 import os
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 

--- a/info.yml
+++ b/info.yml
@@ -67,6 +67,7 @@ description: "Sends sequences in Flame to Flow Production Tracking Review."
 requires_shotgun_version:
 requires_core_version: "v0.18.45"
 requires_engine_version: "v1.14.3"
+minimum_python_version: "3.9"
 
 # the frameworks required to run this app
 frameworks:


### PR DESCRIPTION
## Summary

- Sets `minimum_python_version: "3.9"` in `info.yml`
- Bumps pre-commit hook versions and applies black formatting

## Testing

- Automated check script reports 0 failures
- `pre-commit run --all-files` passes